### PR TITLE
Make job args available to before filter

### DIFF
--- a/default.gems
+++ b/default.gems
@@ -1,0 +1,4 @@
+# default.gems generated gem export file. Note that any env variable settings will be missing. Append these after using a ';' field separator
+beanstalk-client -v1.1.0
+contest -v0.1.3
+mocha -v0.9.12

--- a/lib/stalker.rb
+++ b/lib/stalker.rb
@@ -77,7 +77,7 @@ module Stalker
       Timeout::timeout(job.ttr - 1) do
         if defined? @@before_handlers and @@before_handlers.respond_to? :each
           @@before_handlers.each do |block|
-            block.call(name, args)
+            block.arity == 1 ? block.call(name) : block.call(name,args)
           end
         end
         handler.call(args)

--- a/lib/stalker.rb
+++ b/lib/stalker.rb
@@ -77,7 +77,7 @@ module Stalker
       Timeout::timeout(job.ttr - 1) do
         if defined? @@before_handlers and @@before_handlers.respond_to? :each
           @@before_handlers.each do |block|
-            block.call(name)
+            block.call(name, args)
           end
         end
         handler.call(args)

--- a/test/stalker_test.rb
+++ b/test/stalker_test.rb
@@ -77,6 +77,15 @@ class StalkerTest < Test::Unit::TestCase
     Stalker.work_one_job
     assert_equal true, $handled
   end
+  
+  test "before filter sees args" do
+    Stalker.before { |name, args| $args = args }
+    Stalker.job('my.job') {  }
+    Stalker.enqueue('my.job', :foo => 123)
+    Stalker.prep
+    Stalker.work_one_job
+    assert_equal({'foo' => 123}, $args)
+  end
 
   test "before filter passes the name of the job" do
     Stalker.before { |name| $jobname = name }


### PR DESCRIPTION
I have a use case where I need to log jobs (with args) before any processing is done.  This commit makes this possible.
