### PR TITLE
Pass :beanstalk_job_id in args to help deduplication

### DIFF
--- a/lib/stalker.rb
+++ b/lib/stalker.rb
@@ -69,6 +69,7 @@ module Stalker
   def work_one_job
     job = beanstalk.reserve
     name, args = JSON.parse job.body
+    args[:beanstalk_job_id] = job.id
     log_job_begin(name, args)
     handler = @@handlers[name]
     raise(NoSuchJob, name) unless handler


### PR DESCRIPTION
This patch adds :beanstalk_job_id in args to help avoid running duplicate tasks.
