### PR TITLE
Prevent bin/stalk from polluting Object with Stalker methods

### DIFF
--- a/bin/stalk
+++ b/bin/stalk
@@ -3,7 +3,7 @@
 STDERR.sync = STDOUT.sync = true
 
 require File.expand_path('../../lib/stalker', __FILE__)
-include Stalker
+extend Stalker
 
 usage = "stalk <jobs.rb> [<job>[,<job>,..]]"
 file = ARGV.shift or abort usage


### PR DESCRIPTION
Calling 'include Stalker' in the context of main (which is an instance
of Object) also extends Object with the class/instance methods from
Stalker, which basically pollutes all objects in an application.

Here is a gist which demonstrates the behaviour:

https://gist.github.com/2231315

And this ticket which is probably related:

https://github.com/adamwiggins/stalker/pull/14

Calling 'extend Stalker' works on the instance of the current object.
When used in the context of main, all the methods from Stalker are
loaded and the global Object isn't polluted.
