### PR TITLE
Small typo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ In a standalone file, typically jobs.rb or worker.rb:
 
     job 'post.cleanup.all' do |args|
       Post.all.each do |post|
-        enqueue('post.cleanup', :id => post.all)
+        enqueue('post.cleanup', :id => post.id)
       end
     end
 


### PR DESCRIPTION
Noticed that on the README there's a piece of code like this:

``` ruby
job 'post.cleanup.all' do |args|
  Post.all.each do |post|
    enqueue('post.cleanup', :id => post.all)
  end
end
```

And I believe it should be:

``` ruby
job 'post.cleanup.all' do |args|
  Post.all.each do |post|
    enqueue('post.cleanup', :id => post.id)
  end
end
```

Didn't think it was worth creating a issue, so I just went ahead and did this
