### PR TITLE
Trap "TERM" signals to allow finishing the current job and executing all the needed cleanup code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 pkg
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,1 @@
+gemspec

--- a/lib/stalker.rb
+++ b/lib/stalker.rb
@@ -61,7 +61,8 @@ module Stalker
 
   def work(jobs=nil)
     prep(jobs)
-    loop { work_one_job }
+    trap('TERM') { @stop = true; log "SIGTERM trapped, will stop ASAP" }
+    loop { work_one_job; break if @stop }
   end
 
   class JobTimeout < RuntimeError; end
@@ -72,7 +73,6 @@ module Stalker
     log_job_begin(name, args)
     handler = @@handlers[name]
     raise(NoSuchJob, name) unless handler
-
     begin
       Timeout::timeout(job.ttr - 1) do
         if defined? @@before_handlers and @@before_handlers.respond_to? :each

--- a/stalker.gemspec
+++ b/stalker.gemspec
@@ -33,20 +33,10 @@ Gem::Specification.new do |s|
     "examples/jobs.rb",
     "test/stalker_test.rb"
   ]
+  s.add_dependency "beanstalk-client"
+  s.add_dependency "json_pure"
+  s.add_development_dependency "contest", "~> 0.1.3"
+  s.add_development_dependency 'mocha'
 
-  if s.respond_to? :specification_version then
-    s.specification_version = 3
-
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<beanstalk-client>, [">= 0"])
-      s.add_runtime_dependency(%q<json_pure>, [">= 0"])
-    else
-      s.add_dependency(%q<beanstalk-client>, [">= 0"])
-      s.add_dependency(%q<json_pure>, [">= 0"])
-    end
-  else
-    s.add_dependency(%q<beanstalk-client>, [">= 0"])
-    s.add_dependency(%q<json_pure>, [">= 0"])
-  end
 end
 

--- a/test/interrupt_test.rb
+++ b/test/interrupt_test.rb
@@ -1,0 +1,63 @@
+require File.expand_path('../../lib/stalker', __FILE__)
+require 'contest'
+require 'mocha'
+require 'thread'
+
+
+class InterruptTest < Test::Unit::TestCase
+  setup do
+    Stalker.clear!
+    $result = -1
+    $handled = false
+    Stalker.job('my.job') { |args| args["timeout"].to_i.times { sleep 1 }; $result = args["val"]; puts "done" }
+    flush
+    Thread.new do safe_harakiri end
+  end
+
+  def safe_harakiri(timeout=1)
+    # puts
+    # puts "katana in position, waiting for inspiration."
+    sleep timeout
+    # puts "today is a good day to die"
+    Process.kill("TERM", $$)
+  end
+
+  def flush
+    loop do
+      begin
+        Stalker.beanstalk.reserve(1).delete
+      rescue Beanstalk::TimedOut
+        break
+      end
+    end
+  end
+
+  test "receiving an interrupt signal will allow finishing a job" do
+    begin
+      Stalker.enqueue('my.job', "val" => "done", "timeout" => 2)
+      Stalker.work
+      # puts $result.inspect
+      assert_equal "done", $result
+    ensure
+      flush
+    end
+  end
+
+  test "receiving an interrupt signal will stop processing new jobs" do
+    puts "starting test"
+    begin
+      Stalker.enqueue('my.job', "val" => "first", "timeout" => 2)
+      Stalker.enqueue('my.job', "val" => "second", "timeout" => 2)
+      Stalker.work
+      assert_equal "first", $result
+      next_job = Stalker.beanstalk.reserve(1)
+      name, args = JSON.parse next_job.body
+      assert_equal 'my.job', name
+      assert_equal "second", args["val"]
+      next_job.delete
+    ensure
+      flush
+    end
+  end
+
+end


### PR DESCRIPTION
When the stalker workers are restarted (for instance by god or whatever other mean) if they are in the middle of a job which is not idempotent, it's not safe to just kill them in the middle of a job, as it may leave the universe in an incoherent state.

Letting the worker finish its job (up to when the process controller decides to send a SIGKILL) will avoid most of these problems.
