### PR TITLE
Use File.expand_path to make path absolute.

### DIFF
--- a/bin/stalk
+++ b/bin/stalk
@@ -9,9 +9,9 @@ usage = "stalk <jobs.rb> [<job>[,<job>,..]]"
 file = ARGV.shift or abort usage
 jobs = ARGV.shift.split(',') rescue nil
 
-file = "./#{file}" unless file.match(/^[\/.]/)
+file = File.expand_path(file)
 
-require file
+load file
 
 trap('INT') do
 	puts "\rExiting"


### PR DESCRIPTION
Use load instead of require to allow files without an extension to be loaded
