### PR TITLE
Added enqueue_with_response

### DIFF
--- a/test/stalker_test.rb
+++ b/test/stalker_test.rb
@@ -31,6 +31,18 @@ class StalkerTest < Test::Unit::TestCase
     assert_equal val, $result
   end
 
+  test "enqueue and work a job with response" do
+    val = rand(999999)
+    worker = Thread.new {
+      Stalker.job('my.job') { |args| args['val'] }
+      Stalker.prep
+      Stalker.work_one_job
+    }
+    result = Stalker.enqueue_with_response('my.job', {:val => val}, :timeout => 10)
+    worker.kill
+    assert_equal val, result['val']
+  end
+
   test "invoke error handler when defined" do
     with_an_error_handler
     Stalker.job('my.job') { |args| fail }

--- a/test/stalker_test.rb
+++ b/test/stalker_test.rb
@@ -31,18 +31,6 @@ class StalkerTest < Test::Unit::TestCase
     assert_equal val, $result
   end
 
-  test "enqueue and work a job with response" do
-    val = rand(999999)
-    worker = Thread.new {
-      Stalker.job('my.job') { |args| args['val'] }
-      Stalker.prep
-      Stalker.work_one_job
-    }
-    result = Stalker.enqueue_with_response('my.job', {:val => val}, :timeout => 10)
-    worker.kill
-    assert_equal val, result['val']
-  end
-
   test "invoke error handler when defined" do
     with_an_error_handler
     Stalker.job('my.job') { |args| fail }


### PR DESCRIPTION
New method enqueue_with_response for RPC kind of functionality:

```
job "concat" do |args|
   args['a'] + args['b']
end

Stalker.enqueue_with_response "concat", :a => 'foo', :b => 'bar'
 => "foobar"
```

I dont' see how it could be tested in single thread.
